### PR TITLE
feat: 오늘 현재시각 이전 블럭 opacity 50% 처리 (#21)

### DIFF
--- a/src/components/calendar/DailyTimeline.tsx
+++ b/src/components/calendar/DailyTimeline.tsx
@@ -209,6 +209,23 @@ export const DailyTimeline = ({ events, onEventClick, selectedDate }: DailyTimel
             {isActive && currentTimeTop !== null && (
               <CurrentTimeIndicator ref={currentTimeRef} top={currentTimeTop} />
             )}
+
+            {/* 오늘 현재시각 이전 영역 반투명 오버레이 */}
+            {isActive && currentTimeTop !== null && (
+              <div
+                className={css({
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  background: "white",
+                  opacity: 0.5,
+                  pointerEvents: "none",
+                  zIndex: 5,
+                })}
+                style={{ height: `${currentTimeTop}px` }}
+              />
+            )}
           </div>
 
           {/* 현재 시간 라벨 */}


### PR DESCRIPTION
## 변경 사항
- 오늘 날짜 타임라인에서 현재 시각 이전 영역에 반투명 오버레이 추가
- 이미 지난 시간대는 신경쓸 필요 없으므로 시각적으로 구분

## 구현
- `DailyTimeline.tsx`에 white 배경 + opacity 0.5 오버레이 div 추가
- `pointer-events: none`으로 클릭 통과
- `z-index: 5` (CurrentTimeIndicator보다 낮게)

Closes #21